### PR TITLE
Update mosh to 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # Based on from https://github.com/javabrett/mosh/blob/docker/dockerfiles/Dockerfile.alpine
 FROM alpine
 
-ARG MOSH_VERSION=1.3.2
+ARG MOSH_VERSION=1.4.0
+ENV MOSH=mosh-${MOSH_VERSION}
 
 RUN apk update && \
   apk --no-cache add \
-  git \
-  autoconf \
-  automake \
-  build-base \
+  curl \
+  perl \
+  gzip \
+  clang \
+  make \
   ncurses-dev \
   ncurses-static \
   openssh-client \
@@ -19,15 +21,19 @@ RUN apk update && \
   protobuf-dev \
   zlib-static \
   zlib-dev \
+  abseil-cpp-dev \
   libutempter-dev
 
 # Build as static file
-RUN git clone --depth=1 --branch mosh-${MOSH_VERSION} https://github.com/mobile-shell/mosh.git  && \
-    cd mosh && \
-    ./autogen.sh && LDFLAGS=-static ./configure && make
+ENV CPPFLAGS=-std=c++17
+ENV LDFLAGS=-static
+RUN curl -sLO https://github.com/mobile-shell/mosh/releases/download/mosh-${MOSH_VERSION}/${MOSH}.tar.gz && \
+    tar xvfz ${MOSH}.tar.gz && \
+    cd ${MOSH} && \
+    ./configure && make
 
-
-FROM scratch
-
-COPY --from=0 /mosh/src/frontend/mosh-server /
-COPY --from=0 /mosh/src/frontend/mosh-client /
+#
+# FROM scratch
+#
+# COPY --from=0 /mosh/src/frontend/mosh-server /
+# COPY --from=0 /mosh/src/frontend/mosh-client /


### PR DESCRIPTION
Static building is not working because protobuf doesn't include static libraries, might need to build protobuf before